### PR TITLE
fix: fix crash on ctrl-c cancel since Node.js v24.2

### DIFF
--- a/src/historySearcher.ts
+++ b/src/historySearcher.ts
@@ -526,7 +526,22 @@ export default class HistorySearcher extends AutoComplete {
     const { submitted, cancelled } = this.state
 
     signale.debug('HistorySearcher close()', { input, focused, submitted, cancelled })
-    this.emit('close')
+
+    try {
+      this.emit('close')
+    } catch (error) {
+      /**
+       * [BUG enquirer] on ctrl-c, node closes its readline interface first,
+       * then enquirer keypress cleanup for `close` event calls `rl.pause()`,
+       * which throws ERR_USE_AFTER_CLOSE since Node.js v24.2
+       *
+       * https://github.com/zthxxx/zsh-history-enquirer/issues/75
+       */
+      if ((error as NodeJS.ErrnoException)?.code !== 'ERR_USE_AFTER_CLOSE') {
+        throw error
+      }
+      signale.debug('HistorySearcher close(), ignored readline ERR_USE_AFTER_CLOSE')
+    }
   }
 
   async submit() {

--- a/tests/searchHistory.test.ts
+++ b/tests/searchHistory.test.ts
@@ -437,6 +437,44 @@ test('cancel with ctrl+c', async () => {
   }
 })
 
+test('cancel with ctrl+c on closed readline', async () => {
+  try {
+    await searchHistory(
+      '',
+      async (searcher) => {
+        await keypress(
+          searcher,
+          [2, 3, 3, 3],
+        )
+
+        /**
+         * simulate enquirer keypress cleanup in real tty since Node.js v24.2,
+         * where `rl.pause()` throws ERR_USE_AFTER_CLOSE in `close` event,
+         * because node already closed its readline interface on ctrl-c
+         *
+         * https://github.com/zthxxx/zsh-history-enquirer/issues/75
+         */
+        searcher.once('close', () => {
+          const error = new Error('readline was closed') as NodeJS.ErrnoException
+          error.code = 'ERR_USE_AFTER_CLOSE'
+          throw error
+        })
+
+        await keypress(
+          searcher,
+          [
+            [ctrlC.sequence, ctrlC],
+          ],
+        )
+      },
+    )
+
+    expect(true).toBe(false)
+  } catch (result) {
+    expect(result).toBe('2333')
+  }
+})
+
 test('cancel with esc', async () => {
   try {
     await searchHistory(


### PR DESCRIPTION
on ctrl-c, node closes its readline interface first, then enquirer keypress cleanup for `close` event calls `rl.pause()`, which throws ERR_USE_AFTER_CLOSE since Node.js v24.2 (fine on v24.1 and below)

added a regression test next to the existing ctrl-c cancel test, all tests pass

fixes #75